### PR TITLE
Catch SIGTERM to allow results to be collected from terminated containers

### DIFF
--- a/run-bids-app.sh
+++ b/run-bids-app.sh
@@ -98,7 +98,9 @@ function sync_output {
     # Cleanup at end of job
     docker_cleanup
 }
-trap sync_output EXIT
+
+# On EXIT or SIGTERM, sync results
+trap sync_output EXIT SIGTERM
 
 # Create volumes for snapshot/output if they do not already exist
 echo "Creating snapshot volume:"


### PR DESCRIPTION
This fixes OpenNeuroOrg/openneuro/issues/292